### PR TITLE
Potential fix for code scanning alert no. 15: Useless null check

### DIFF
--- a/src/main/kotlin/tsuki/site/es/MangaOni.kt
+++ b/src/main/kotlin/tsuki/site/es/MangaOni.kt
@@ -265,7 +265,7 @@ internal class MangaOni(context: MangaLoaderContext) :
             val name = element.text()
             val chNum = element.select("span").attr("data-num").toFloatOrNull() ?: -1f
             val dateStr = element.select("span").attr("datetime")
-            val uploadDate = dateStr?.let { dateFormat.parseSafe(it) } ?: 0L
+            val uploadDate = dateFormat.parseSafe(dateStr) ?: 0L
             MangaChapter(
                 id = generateUid(chHref),
                 url = chHref,


### PR DESCRIPTION
Potential fix for [https://github.com/InvalidDavid/UMA/security/code-scanning/15](https://github.com/InvalidDavid/UMA/security/code-scanning/15)

Remove the useless null-safe call and keep behavior unchanged by directly parsing the string and preserving the same fallback to `0L` when parsing fails.

Best fix in this file region (`getDetails`, around lines 267–268):
- Keep `dateStr` assignment as-is.
- Replace:
  - `val uploadDate = dateStr?.let { dateFormat.parseSafe(it) } ?: 0L`
- With:
  - `val uploadDate = dateFormat.parseSafe(dateStr) ?: 0L`

This preserves existing functionality:
- If `datetime` is absent, `attr("datetime")` gives `""`.
- `parseSafe("")` should return `null` (same as failed parse), then `?: 0L` applies exactly as before.

No imports, new methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
